### PR TITLE
Fix path variables for Decap CMS items

### DIFF
--- a/src/static/cms/admin/config.yml
+++ b/src/static/cms/admin/config.yml
@@ -8,7 +8,7 @@ collections:
   - label: "Articles"
     label_singular: "Article"
     name: "articles"
-    folder: "/articles/"
+    folder: "/src/articles/"
     extension: "html"
     format: "yaml-frontmatter"
     frontmatter_delimiter: [
@@ -31,7 +31,7 @@ collections:
     files:
       - label: "Article listing"
         name: "links_articles"
-        file: "/static/data/links/articles.json"
+        file: "/src/static/data/links/articles.json"
         extension: "json"
         format: "json"
         fields:
@@ -54,7 +54,7 @@ collections:
 
       - label: "Page navigation"
         name: "links_pages"
-        file: "/static/data/links/pages.json"
+        file: "/src/static/data/links/pages.json"
         extension: "json"
         format: "json"
         fields:


### PR DESCRIPTION
## Summary
This pull request fixes the path variables for Decap CMS items to ensure correct routing and file handling.

## Changes
- Adjusted path variables to correctly resolve item locations.
- Verified compatibility with existing routes and structure.

## Related Issues
closes #2 
